### PR TITLE
Removing ECR as prerequisite for tagging commit/date/branch

### DIFF
--- a/mk/scripts/docker-tag-wrapper
+++ b/mk/scripts/docker-tag-wrapper
@@ -197,26 +197,25 @@ end
 tag_list = []
 pull_tag_list = []
 remote_tag_prefix = "#{$args.registry}/#{$args.repository}"
-if $args.label_ecr then
-  tag = "#{remote_tag_prefix}:#{$args.image}-commit-#{$args.build_sha}"
-  tag_list << tag
+
+tag = "#{remote_tag_prefix}:#{$args.image}-commit-#{$args.build_sha}"
+tag_list << tag
+pull_tag_list << tag
+
+tag = "#{remote_tag_prefix}:#{$args.image}-branch-#{$args.branch}"
+tag_list << tag
+pull_tag_list << tag
+
+if $args.label_latest then
+  tag = "#{remote_tag_prefix}:#{$args.image}-#{$args.branch}-latest"
+  tag_list <<  tag
   pull_tag_list << tag
-
-  tag = "#{remote_tag_prefix}:#{$args.image}-branch-#{$args.branch}"
-  tag_list << tag
-  pull_tag_list << tag
-
-  if $args.label_latest then
-    tag = "#{remote_tag_prefix}:#{$args.image}-#{$args.branch}-latest"
-    tag_list <<  tag
-    pull_tag_list << tag
-  end
-
-  if $args.verb != 'pull' then
-    tag_list << "#{remote_tag_prefix}:#{$args.image}-build-#{$args.build_date}"
-  end
-  tag_list << "#{remote_tag_prefix}:#{$args.image}"
 end
+
+if $args.verb != 'pull' then
+  tag_list << "#{remote_tag_prefix}:#{$args.image}-build-#{$args.build_date}"
+end
+tag_list << "#{remote_tag_prefix}:#{$args.image}"
 
 if $args.label_latest then
   tag = "#{remote_tag_prefix}:#{$args.image}-latest"


### PR DESCRIPTION
Github seems to have mangled the diff, but all this does is remove

````if $args.label_ecr````

and fix the indentation