### PR TITLE
Force option sent to wrapper should instruct docker to ignore cached layers

### DIFF
--- a/mk/scripts/docker-build-wrapper
+++ b/mk/scripts/docker-build-wrapper
@@ -147,6 +147,7 @@ class DockerBuilder
     if ENV['DOCKER_SQUASH'] then
       cmd << ENV['DOCKER_SQUASH']
     end
+    cmd << %W(--no-cache) if @force
     cmd << %W(-f #{expand_build_path("Dockerfile.#{@docker_name}")})
     @build_arg.each do |arg|
       cmd << %W(--build-arg #{arg})


### PR DESCRIPTION
When `make docker_rebuild_<image>` or `make docker_rebuild` is issued I expect image to be rebuilt. But instead this target removes only timestamp files and Dockerfile and next run of docker build simply reuses cached layers.